### PR TITLE
Converted setup script to mac friendly format

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 APP_PATH="${SCRIPT_PATH}/.."
 
-for d in src/*/ ; do
+for d in src/*/; do
     if [[ ${d} = *"titan-"* ]]; then
          MODULE_PATH=$(cut -d "/" -f 2 <<< "${d}")
          echo "Linking module: ${MODULE_PATH}"

--- a/src/titan-core/lib/titan.js
+++ b/src/titan-core/lib/titan.js
@@ -1,4 +1,4 @@
-import DefaultThemeProvider from '../DefaultThemeProvider'
+import defaultThemeProvider from '../defaultThemeProvider'
 
 /**
  * @param {{modules}} applicationProvider
@@ -11,5 +11,5 @@ export function mountApplicationRoutes (applicationProvider) {
  * @param themeProvider
  */
 export function resolveTheme (themeProvider) {
-  return Object.assign({}, DefaultThemeProvider, themeProvider)
+  return Object.assign({}, defaultThemeProvider, themeProvider)
 }


### PR DESCRIPTION
The  `setup.sh` script was written on a Windows 10 machine. I guess the generated file headers weren't compatible with MacOS. I copied the contents of the file into a new file on MacOS, and the same code worked fine.

I committed the `setup.sh` file I had created on MacOS, and tested it it windows. It works on both operating systems. You shouldn't have any problems executing it.